### PR TITLE
UF-10292: Added the document type attribute to existing document classes

### DIFF
--- a/src/integration-test/resources/DocumentIT/__files/test01_createDocument/request.json
+++ b/src/integration-test/resources/DocumentIT/__files/test01_createDocument/request.json
@@ -8,5 +8,6 @@
 			"key": "Some key",
 			"value": "Some value"
 		}
-	]
+	],
+	"type": "HOLIDAY_EXCHANGE"
 }

--- a/src/main/java/se/sundsvall/document/api/model/Document.java
+++ b/src/main/java/se/sundsvall/document/api/model/Document.java
@@ -48,6 +48,9 @@ public class Document {
 	@Schema(description = "Document data")
 	private List<DocumentData> documentData;
 
+	@Schema(description = "Document type", example = "Type for the document.")
+	private String type;
+
 	public static Document create() {
 		return new Document();
 	}
@@ -195,9 +198,22 @@ public class Document {
 		return this;
 	}
 
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public Document withType(String type) {
+		this.type = type;
+		return this;
+	}
+
 	@Override
 	public int hashCode() {
-		return Objects.hash(archive, confidentiality, created, createdBy, description, documentData, id, metadataList, municipalityId, registrationNumber, revision);
+		return Objects.hash(archive, confidentiality, created, createdBy, description, documentData, id, metadataList, municipalityId, registrationNumber, revision, type);
 	}
 
 	@Override
@@ -205,22 +221,20 @@ public class Document {
 		if (this == obj) {
 			return true;
 		}
-		if (!(obj instanceof Document)) {
+		if (!(obj instanceof final Document other)) {
 			return false;
 		}
-		Document other = (Document) obj;
 		return archive == other.archive && Objects.equals(confidentiality, other.confidentiality) && Objects.equals(created, other.created) && Objects.equals(createdBy, other.createdBy) && Objects.equals(description, other.description) && Objects
 			.equals(documentData, other.documentData) && Objects.equals(id, other.id) && Objects.equals(metadataList, other.metadataList) && Objects.equals(municipalityId, other.municipalityId) && Objects.equals(registrationNumber,
-				other.registrationNumber) && revision == other.revision;
+				other.registrationNumber) && revision == other.revision && Objects.equals(type, other.type);
 	}
 
 	@Override
 	public String toString() {
-		StringBuilder builder = new StringBuilder();
+		final var builder = new StringBuilder();
 		builder.append("Document [id=").append(id).append(", municipalityId=").append(municipalityId).append(", registrationNumber=").append(registrationNumber).append(", revision=").append(revision).append(", confidentiality=").append(
 			confidentiality).append(", description=").append(description).append(", created=").append(created).append(", createdBy=").append(createdBy).append(", archive=").append(archive).append(", metadataList=").append(metadataList).append(
-				", documentData=").append(documentData).append("]");
+				", documentData=").append(documentData).append(", type=").append(type).append("]");
 		return builder.toString();
 	}
-
 }

--- a/src/main/java/se/sundsvall/document/api/model/DocumentCreateRequest.java
+++ b/src/main/java/se/sundsvall/document/api/model/DocumentCreateRequest.java
@@ -33,6 +33,10 @@ public class DocumentCreateRequest {
 	@Schema(description = "List of DocumentMetadata objects.", requiredMode = REQUIRED)
 	private List<@Valid DocumentMetadata> metadataList;
 
+	@NotBlank
+	@Schema(description = "The type of document (validated against a defined list of document types).", example = "EMPLOYMENT_CERTIFICATE", requiredMode = REQUIRED)
+	private String type;
+
 	public static DocumentCreateRequest create() {
 		return new DocumentCreateRequest();
 	}
@@ -102,9 +106,22 @@ public class DocumentCreateRequest {
 		return this;
 	}
 
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public DocumentCreateRequest withType(String type) {
+		this.type = type;
+		return this;
+	}
+
 	@Override
 	public int hashCode() {
-		return Objects.hash(archive, confidentiality, createdBy, description, metadataList);
+		return Objects.hash(archive, confidentiality, createdBy, description, metadataList, type);
 	}
 
 	@Override
@@ -112,19 +129,18 @@ public class DocumentCreateRequest {
 		if (this == obj) {
 			return true;
 		}
-		if (!(obj instanceof DocumentCreateRequest)) {
+		if (!(obj instanceof final DocumentCreateRequest other)) {
 			return false;
 		}
-		DocumentCreateRequest other = (DocumentCreateRequest) obj;
-		return archive == other.archive && Objects.equals(confidentiality, other.confidentiality) && Objects.equals(createdBy, other.createdBy) && Objects.equals(description, other.description) && Objects.equals(metadataList, other.metadataList);
+		return archive == other.archive && Objects.equals(confidentiality, other.confidentiality) && Objects.equals(createdBy, other.createdBy) && Objects.equals(description, other.description) && Objects.equals(metadataList, other.metadataList)
+			&& Objects.equals(type, other.type);
 	}
 
 	@Override
 	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("DocumentCreateRequest [createdBy=").append(createdBy).append(", confidentiality=").append(confidentiality).append(", archive=").append(archive).append(", description=")
-			.append(description).append(", metadataList=").append(metadataList).append("]");
+		final var builder = new StringBuilder();
+		builder.append("DocumentCreateRequest [createdBy=").append(createdBy).append(", confidentiality=").append(confidentiality).append(", archive=").append(archive).append(", description=").append(description).append(", metadataList=").append(
+			metadataList).append(", type=").append(type).append("]");
 		return builder.toString();
 	}
-
 }

--- a/src/main/java/se/sundsvall/document/api/model/DocumentUpdateRequest.java
+++ b/src/main/java/se/sundsvall/document/api/model/DocumentUpdateRequest.java
@@ -27,6 +27,9 @@ public class DocumentUpdateRequest {
 	@Schema(description = "List of DocumentMetadata objects.")
 	private List<@Valid DocumentMetadata> metadataList;
 
+	@Schema(description = "The type of document (validated against a defined list of document types).", example = "EMPLOYMENT_CERTIFICATE")
+	private String type;
+
 	public static DocumentUpdateRequest create() {
 		return new DocumentUpdateRequest();
 	}
@@ -83,9 +86,22 @@ public class DocumentUpdateRequest {
 		return this;
 	}
 
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public DocumentUpdateRequest withType(String type) {
+		this.type = type;
+		return this;
+	}
+
 	@Override
 	public int hashCode() {
-		return Objects.hash(archive, createdBy, description, metadataList);
+		return Objects.hash(archive, createdBy, description, metadataList, type);
 	}
 
 	@Override
@@ -93,17 +109,17 @@ public class DocumentUpdateRequest {
 		if (this == obj) {
 			return true;
 		}
-		if (!(obj instanceof DocumentUpdateRequest)) {
+		if (!(obj instanceof final DocumentUpdateRequest other)) {
 			return false;
 		}
-		DocumentUpdateRequest other = (DocumentUpdateRequest) obj;
-		return Objects.equals(archive, other.archive) && Objects.equals(createdBy, other.createdBy) && Objects.equals(description, other.description) && Objects.equals(metadataList, other.metadataList);
+		return Objects.equals(archive, other.archive) && Objects.equals(createdBy, other.createdBy) && Objects.equals(description, other.description) && Objects.equals(metadataList, other.metadataList) && Objects.equals(type, other.type);
 	}
 
 	@Override
 	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("DocumentUpdateRequest [createdBy=").append(createdBy).append(", description=").append(description).append(", archive=").append(archive).append(", metadataList=").append(metadataList).append("]");
+		final var builder = new StringBuilder();
+		builder.append("DocumentUpdateRequest [createdBy=").append(createdBy).append(", description=").append(description).append(", archive=").append(archive).append(", metadataList=").append(metadataList).append(", type=").append(type).append("]");
 		return builder.toString();
 	}
+
 }

--- a/src/main/java/se/sundsvall/document/api/validation/DocumentTypeValidator.java
+++ b/src/main/java/se/sundsvall/document/api/validation/DocumentTypeValidator.java
@@ -1,0 +1,38 @@
+package se.sundsvall.document.api.validation;
+
+import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.zalando.problem.Status.BAD_REQUEST;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.zalando.problem.violations.ConstraintViolationProblem;
+import org.zalando.problem.violations.Violation;
+
+import se.sundsvall.document.api.model.DocumentType;
+import se.sundsvall.document.service.DocumentTypeService;
+
+@Component
+public class DocumentTypeValidator {
+
+	private final DocumentTypeService documentTypeService;
+
+	DocumentTypeValidator(DocumentTypeService documentTypeService) {
+		this.documentTypeService = documentTypeService;
+	}
+
+	public void validate(final String municipalityId, final String documentType) {
+		if (isNull(documentType)) {
+			return;
+		}
+
+		final var validTypes = documentTypeService.read(municipalityId).stream().map(DocumentType::getType).toList();
+
+		validTypes.stream()
+			.filter(type -> equalsIgnoreCase(type, documentType))
+			.findAny()
+			.orElseThrow(() -> new ConstraintViolationProblem(BAD_REQUEST, List.of(new Violation("type",
+				"document type '%s' must match one of %s".formatted(documentType, validTypes)))));
+	}
+}

--- a/src/test/java/se/sundsvall/document/api/DocumentResourceFailuresTest.java
+++ b/src/test/java/se/sundsvall/document/api/DocumentResourceFailuresTest.java
@@ -3,14 +3,18 @@ package se.sundsvall.document.api;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
 import static org.springframework.web.reactive.function.BodyInserters.fromMultipartData;
+import static org.zalando.problem.Status.BAD_REQUEST;
 
 import java.util.List;
 
@@ -26,11 +30,14 @@ import org.zalando.problem.violations.ConstraintViolationProblem;
 import org.zalando.problem.violations.Violation;
 
 import se.sundsvall.document.Application;
+import se.sundsvall.document.api.model.Confidentiality;
 import se.sundsvall.document.api.model.ConfidentialityUpdateRequest;
+import se.sundsvall.document.api.model.Document;
 import se.sundsvall.document.api.model.DocumentCreateRequest;
 import se.sundsvall.document.api.model.DocumentDataCreateRequest;
 import se.sundsvall.document.api.model.DocumentMetadata;
 import se.sundsvall.document.api.model.DocumentUpdateRequest;
+import se.sundsvall.document.api.validation.DocumentTypeValidator;
 import se.sundsvall.document.service.DocumentService;
 
 @SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
@@ -39,6 +46,9 @@ class DocumentResourceFailuresTest {
 
 	@MockBean
 	private DocumentService documentServiceMock;
+
+	@MockBean
+	private DocumentTypeValidator validationUtilityMock;
 
 	@Autowired
 	private WebTestClient webTestClient;
@@ -70,6 +80,44 @@ class DocumentResourceFailuresTest {
 	}
 
 	@Test
+	void createWithDuplicateFileNames() {
+		final var documentCreateRequest = DocumentCreateRequest.create()
+			.withConfidentiality(Confidentiality.create().withConfidential(true).withLegalCitation("legalCitation"))
+			.withCreatedBy("user")
+			.withDescription("description")
+			.withType("type")
+			.withMetadataList(List.of(DocumentMetadata.create()
+				.withKey("key")
+				.withValue("value")));
+
+		final var multipartBodyBuilder = new MultipartBodyBuilder();
+		multipartBodyBuilder.part("documentFiles", "file-content").filename("duplicateName.txt").contentType(TEXT_PLAIN);
+		multipartBodyBuilder.part("documentFiles", "file-content").filename("duplicateName.txt").contentType(TEXT_PLAIN);
+		multipartBodyBuilder.part("document", documentCreateRequest);
+
+		when(documentServiceMock.create(any(), any(), any())).thenReturn(Document.create());
+
+		final var response = webTestClient.post()
+			.uri("/2281/documents")
+			.contentType(MULTIPART_FORM_DATA)
+			.body(fromMultipartData(multipartBodyBuilder.build()))
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(response).satisfies(problem -> {
+			assertThat(problem.getTitle()).isEqualTo("Constraint Violation");
+			assertThat(problem.getStatus()).isEqualTo(BAD_REQUEST);
+			assertThat(problem.getViolations()).extracting("field", "message")
+				.containsExactlyInAnyOrder(tuple("files", "no duplicate file names allowed in the list of files"));
+		});
+
+		verifyNoInteractions(documentServiceMock);
+	}
+
+	@Test
 	void createWithMissingDocument() {
 
 		// Arrange
@@ -96,7 +144,7 @@ class DocumentResourceFailuresTest {
 	}
 
 	@Test
-	void createWithMissingDescription() {
+	void createWithMissingDescriptionAndType() {
 
 		// Arrange
 		final var multipartBodyBuilder = new MultipartBodyBuilder();
@@ -123,7 +171,9 @@ class DocumentResourceFailuresTest {
 		assertThat(response).isNotNull();
 		assertThat(response.getViolations())
 			.extracting(Violation::getField, Violation::getMessage)
-			.containsExactlyInAnyOrder(tuple("description", "must not be blank"));
+			.containsExactlyInAnyOrder(
+				tuple("description", "must not be blank"),
+				tuple("type", "must not be blank"));
 
 		verifyNoInteractions(documentServiceMock);
 	}
@@ -137,6 +187,7 @@ class DocumentResourceFailuresTest {
 		multipartBodyBuilder.part("document", DocumentCreateRequest.create()
 			.withDescription(repeat("x", 8193)) // 8192 is max length on description.
 			.withCreatedBy("user")
+			.withType("type")
 			.withMetadataList(List.of(DocumentMetadata.create()
 				.withKey("key")
 				.withValue("value"))));
@@ -171,6 +222,7 @@ class DocumentResourceFailuresTest {
 		multipartBodyBuilder.part("document", DocumentCreateRequest.create()
 			.withCreatedBy("user")
 			.withDescription("description")
+			.withType("type")
 			.withMetadataList(emptyList()));
 
 		// Act
@@ -202,6 +254,7 @@ class DocumentResourceFailuresTest {
 		multipartBodyBuilder.part("documentFiles", "file-content").filename("test.txt").contentType(TEXT_PLAIN);
 		multipartBodyBuilder.part("document", DocumentCreateRequest.create()
 			.withDescription("description")
+			.withType("type")
 			.withCreatedBy("user"));
 
 		// Act
@@ -221,6 +274,43 @@ class DocumentResourceFailuresTest {
 		assertThat(response.getViolations())
 			.extracting(Violation::getField, Violation::getMessage)
 			.containsExactlyInAnyOrder(tuple("metadataList", "must not be empty"));
+
+		verifyNoInteractions(documentServiceMock);
+	}
+
+	@Test
+	void createWithInvalidType() {
+		doThrow(new ConstraintViolationProblem(BAD_REQUEST, List.of(new Violation("type", "error")))).when(validationUtilityMock).validate(any(), any());
+		final var documentCreateRequest = DocumentCreateRequest.create()
+			.withConfidentiality(Confidentiality.create().withConfidential(true).withLegalCitation("legalCitation"))
+			.withCreatedBy("user")
+			.withDescription("description")
+			.withMetadataList(List.of(DocumentMetadata.create()
+				.withKey("key")
+				.withValue("value")))
+			.withType("type");
+		final var multipartBodyBuilder = new MultipartBodyBuilder();
+		multipartBodyBuilder.part("documentFiles", "file-content").filename("test1.txt").contentType(TEXT_PLAIN);
+		multipartBodyBuilder.part("documentFiles", "file-content").filename("tesst2.txt").contentType(TEXT_PLAIN);
+		multipartBodyBuilder.part("document", documentCreateRequest);
+
+		// Act
+		final var response = webTestClient.post()
+			.uri("/2281/documents")
+			.contentType(MULTIPART_FORM_DATA)
+			.body(fromMultipartData(multipartBodyBuilder.build()))
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectHeader().contentType(APPLICATION_PROBLEM_JSON)
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult()
+			.getResponseBody();
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getViolations())
+			.extracting(Violation::getField, Violation::getMessage)
+			.containsExactlyInAnyOrder(tuple("type", "error"));
 
 		verifyNoInteractions(documentServiceMock);
 	}
@@ -386,6 +476,37 @@ class DocumentResourceFailuresTest {
 		assertThat(response.getViolations())
 			.extracting(Violation::getField, Violation::getMessage)
 			.containsExactlyInAnyOrder(tuple("description", "size must be between 0 and 8192"));
+
+		verifyNoInteractions(documentServiceMock);
+	}
+
+	@Test
+	void updateWithInvalidType() {
+		doThrow(new ConstraintViolationProblem(BAD_REQUEST, List.of(new Violation("type", "error")))).when(validationUtilityMock).validate(any(), any());
+		final var requestBody = DocumentUpdateRequest.create()
+			.withCreatedBy("user")
+			.withType("type")
+			.withMetadataList(List.of(DocumentMetadata.create()
+				.withKey("key")
+				.withValue("value")));
+
+		// Act
+		final var response = webTestClient.patch()
+			.uri("/2281/documents/2023-1337")
+			.contentType(APPLICATION_JSON)
+			.bodyValue(requestBody)
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectHeader().contentType(APPLICATION_PROBLEM_JSON)
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult()
+			.getResponseBody();
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getViolations())
+			.extracting(Violation::getField, Violation::getMessage)
+			.containsExactlyInAnyOrder(tuple("type", "error"));
 
 		verifyNoInteractions(documentServiceMock);
 	}

--- a/src/test/java/se/sundsvall/document/api/DocumentResourceTest.java
+++ b/src/test/java/se/sundsvall/document/api/DocumentResourceTest.java
@@ -2,12 +2,10 @@ package se.sundsvall.document.api;
 
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.data.domain.Sort.Order.asc;
@@ -17,7 +15,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
 import static org.springframework.web.reactive.function.BodyInserters.fromMultipartData;
-import static org.zalando.problem.Status.BAD_REQUEST;
 
 import java.util.List;
 
@@ -34,7 +31,6 @@ import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.multipart.MultipartFile;
-import org.zalando.problem.violations.ConstraintViolationProblem;
 
 import jakarta.servlet.http.HttpServletResponse;
 import se.sundsvall.document.Application;
@@ -47,6 +43,7 @@ import se.sundsvall.document.api.model.DocumentFiles;
 import se.sundsvall.document.api.model.DocumentMetadata;
 import se.sundsvall.document.api.model.DocumentUpdateRequest;
 import se.sundsvall.document.api.model.PagedDocumentResponse;
+import se.sundsvall.document.api.validation.DocumentTypeValidator;
 import se.sundsvall.document.service.DocumentService;
 
 @SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
@@ -55,6 +52,9 @@ class DocumentResourceTest {
 
 	@MockBean
 	private DocumentService documentServiceMock;
+
+	@MockBean
+	private DocumentTypeValidator validationUtilityMock;
 
 	@Autowired
 	private WebTestClient webTestClient;
@@ -69,7 +69,8 @@ class DocumentResourceTest {
 			.withDescription("description")
 			.withMetadataList(List.of(DocumentMetadata.create()
 				.withKey("key")
-				.withValue("value")));
+				.withValue("value")))
+			.withType("type");
 
 		final var multipartBodyBuilder = new MultipartBodyBuilder();
 		multipartBodyBuilder.part("documentFiles", "file-content").filename("test1.txt").contentType(TEXT_PLAIN);
@@ -93,43 +94,6 @@ class DocumentResourceTest {
 		// Assert
 		assertThat(response).isNotNull();
 		verify(documentServiceMock).create(eq(documentCreateRequest), ArgumentMatchers.<DocumentFiles>any(), eq("2281"));
-	}
-
-	@Test
-	void createWithDuplicateFileNames() {
-		final var documentCreateRequest = DocumentCreateRequest.create()
-			.withConfidentiality(Confidentiality.create().withConfidential(true).withLegalCitation("legalCitation"))
-			.withCreatedBy("user")
-			.withDescription("description")
-			.withMetadataList(List.of(DocumentMetadata.create()
-				.withKey("key")
-				.withValue("value")));
-
-		final var multipartBodyBuilder = new MultipartBodyBuilder();
-		multipartBodyBuilder.part("documentFiles", "file-content").filename("duplicateName.txt").contentType(TEXT_PLAIN);
-		multipartBodyBuilder.part("documentFiles", "file-content").filename("duplicateName.txt").contentType(TEXT_PLAIN);
-		multipartBodyBuilder.part("document", documentCreateRequest);
-
-		when(documentServiceMock.create(any(), any(), any())).thenReturn(Document.create());
-
-		final var response = webTestClient.post()
-			.uri("/2281/documents")
-			.contentType(MULTIPART_FORM_DATA)
-			.body(fromMultipartData(multipartBodyBuilder.build()))
-			.exchange()
-			.expectStatus().isBadRequest()
-			.expectBody(ConstraintViolationProblem.class)
-			.returnResult()
-			.getResponseBody();
-
-		assertThat(response).satisfies(problem -> {
-			assertThat(problem.getTitle()).isEqualTo("Constraint Violation");
-			assertThat(problem.getStatus()).isEqualTo(BAD_REQUEST);
-			assertThat(problem.getViolations()).extracting("field", "message")
-				.containsExactlyInAnyOrder(tuple("files", "no duplicate file names allowed in the list of files"));
-		});
-
-		verifyNoInteractions(documentServiceMock);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/document/api/model/DocumentCreateRequestTest.java
+++ b/src/test/java/se/sundsvall/document/api/model/DocumentCreateRequestTest.java
@@ -33,13 +33,15 @@ class DocumentCreateRequestTest {
 		final var createdBy = "user";
 		final var description = "description";
 		final var metadataList = List.of(DocumentMetadata.create());
+		final var type = "type";
 
 		final var bean = DocumentCreateRequest.create()
 			.withArchive(archive)
 			.withConfidentiality(confidentiality)
 			.withCreatedBy(createdBy)
 			.withDescription(description)
-			.withMetadataList(metadataList);
+			.withMetadataList(metadataList)
+			.withType(type);
 
 		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(bean.isArchive()).isEqualTo(archive);
@@ -47,6 +49,7 @@ class DocumentCreateRequestTest {
 		assertThat(bean.getCreatedBy()).isEqualTo(createdBy);
 		assertThat(bean.getDescription()).isEqualTo(description);
 		assertThat(bean.getMetadataList()).isEqualTo(metadataList);
+		assertThat(bean.getType()).isEqualTo(type);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/document/api/model/DocumentTest.java
+++ b/src/test/java/se/sundsvall/document/api/model/DocumentTest.java
@@ -51,6 +51,7 @@ class DocumentTest {
 		final var municipalityId = "municipalityId";
 		final var registrationNumber = "12345";
 		final var revision = 5;
+		final var type = "type";
 
 		final var bean = Document.create()
 			.withArchive(archive)
@@ -63,7 +64,8 @@ class DocumentTest {
 			.withMetadataList(metadataList)
 			.withMunicipalityId(municipalityId)
 			.withRegistrationNumber(registrationNumber)
-			.withRevision(revision);
+			.withRevision(revision)
+			.withType(type);
 
 		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(bean.isArchive()).isEqualTo(archive);
@@ -77,6 +79,7 @@ class DocumentTest {
 		assertThat(bean.getMunicipalityId()).isEqualTo(municipalityId);
 		assertThat(bean.getRegistrationNumber()).isEqualTo(registrationNumber);
 		assertThat(bean.getRevision()).isEqualTo(revision);
+		assertThat(bean.getType()).isEqualTo(type);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/document/api/model/DocumentUpdateRequestTest.java
+++ b/src/test/java/se/sundsvall/document/api/model/DocumentUpdateRequestTest.java
@@ -32,18 +32,21 @@ class DocumentUpdateRequestTest {
 		final var createdBy = "user";
 		final var description = "description";
 		final var metadataList = List.of(DocumentMetadata.create());
+		final var type = "type";
 
 		final var bean = DocumentUpdateRequest.create()
 			.withArchive(archive)
 			.withCreatedBy(createdBy)
 			.withDescription(description)
-			.withMetadataList(metadataList);
+			.withMetadataList(metadataList)
+			.withType(type);
 
 		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(bean.getArchive()).isEqualTo(archive);
 		assertThat(bean.getCreatedBy()).isEqualTo(createdBy);
 		assertThat(bean.getDescription()).isEqualTo(description);
 		assertThat(bean.getMetadataList()).isEqualTo(metadataList);
+		assertThat(bean.getType()).isEqualTo(type);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/document/api/validation/DocumentTypeValidatorTest.java
+++ b/src/test/java/se/sundsvall/document/api/validation/DocumentTypeValidatorTest.java
@@ -1,0 +1,66 @@
+package se.sundsvall.document.api.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zalando.problem.Status;
+import org.zalando.problem.violations.ConstraintViolationProblem;
+
+import se.sundsvall.document.api.model.DocumentType;
+import se.sundsvall.document.service.DocumentTypeService;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentTypeValidatorTest {
+
+	@Mock
+	private DocumentTypeService documentTypeServiceMock;
+
+	@InjectMocks
+	private DocumentTypeValidator validator;
+
+	@Test
+	void validateWithNull() {
+		// Arrange
+		final var municipalityId = "municipalityId";
+
+		// Act and assert
+		assertDoesNotThrow(() -> validator.validate(municipalityId, null));
+	}
+
+	@Test
+	void validateWithValidType() {
+		// Arrange
+		final var municipalityId = "municipalityId";
+		final var type = "type";
+		when(documentTypeServiceMock.read(municipalityId)).thenReturn(List.of(DocumentType.create().withType(type)));
+
+		// Act and assert
+		assertDoesNotThrow(() -> validator.validate(municipalityId, type));
+	}
+
+	@Test
+	void validateWithInvalidType() {
+		// Arrange
+		final var municipalityId = "municipalityId";
+		final var type = "type";
+		when(documentTypeServiceMock.read(municipalityId)).thenReturn(List.of(DocumentType.create().withType("othertype")));
+
+		// Act and assert
+		final var e = assertThrows(ConstraintViolationProblem.class, () -> validator.validate(municipalityId, type));
+
+		assertThat(e.getStatus()).isEqualTo(Status.BAD_REQUEST);
+		assertThat(e.getViolations()).hasSize(1).satisfiesExactly(violation -> {
+			assertThat(violation.getField()).isEqualTo("type");
+			assertThat(violation.getMessage()).isEqualTo("document type 'type' must match one of [othertype]");
+		});
+	}
+}

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -54,14 +54,6 @@ paths:
                   type: string
                   format: binary
       responses:
-        "404":
-          description: Not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        "200":
-          description: Successful operation
         "400":
           description: Bad request
           content:
@@ -70,6 +62,14 @@ paths:
                 oneOf:
                 - $ref: "#/components/schemas/Problem"
                 - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "200":
+          description: Successful operation
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
@@ -139,6 +139,14 @@ paths:
           items:
             type: string
       responses:
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "200":
           description: Successful operation
           content:
@@ -148,14 +156,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/PagedDocumentResponse"
-        "400":
-          description: Bad request
-          content:
-            application/problem+json:
-              schema:
-                oneOf:
-                - $ref: "#/components/schemas/Problem"
-                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -192,13 +192,6 @@ paths:
                     type: string
                     format: binary
       responses:
-        "201":
-          description: Successful operation
-          headers:
-            Location:
-              style: simple
-              schema:
-                type: string
         "400":
           description: Bad request
           content:
@@ -207,6 +200,13 @@ paths:
                 oneOf:
                 - $ref: "#/components/schemas/Problem"
                 - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "201":
+          description: Successful operation
+          headers:
+            Location:
+              style: simple
+              schema:
+                type: string
         "500":
           description: Internal Server error
           content:
@@ -229,6 +229,14 @@ paths:
           type: string
         example: 2281
       responses:
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "200":
           description: Successful operation
           content:
@@ -242,14 +250,6 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/DocumentType"
-        "400":
-          description: Bad request
-          content:
-            application/problem+json:
-              schema:
-                oneOf:
-                - $ref: "#/components/schemas/Problem"
-                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -277,13 +277,6 @@ paths:
               $ref: "#/components/schemas/DocumentTypeCreateRequest"
         required: true
       responses:
-        "201":
-          description: Successful operation
-          headers:
-            Location:
-              style: simple
-              schema:
-                type: string
         "400":
           description: Bad request
           content:
@@ -292,6 +285,13 @@ paths:
                 oneOf:
                 - $ref: "#/components/schemas/Problem"
                 - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "201":
+          description: Successful operation
+          headers:
+            Location:
+              style: simple
+              schema:
+                type: string
         "500":
           description: Internal Server error
           content:
@@ -328,12 +328,14 @@ paths:
           default: false
         example: true
       responses:
-        "404":
-          description: Not found
+        "400":
+          description: Bad request
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/Problem"
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "200":
           description: Successful operation
           content:
@@ -343,14 +345,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Document"
-        "400":
-          description: Bad request
+        "404":
+          description: Not found
           content:
             application/problem+json:
               schema:
-                oneOf:
-                - $ref: "#/components/schemas/Problem"
-                - $ref: "#/components/schemas/ConstraintViolationProblem"
+                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
@@ -392,12 +392,14 @@ paths:
               $ref: "#/components/schemas/DocumentUpdateRequest"
         required: true
       responses:
-        "404":
-          description: Not found
+        "400":
+          description: Bad request
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/Problem"
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "200":
           description: Successful operation
           content:
@@ -407,14 +409,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Document"
-        "400":
-          description: Bad request
+        "404":
+          description: Not found
           content:
             application/problem+json:
               schema:
-                oneOf:
-                - $ref: "#/components/schemas/Problem"
-                - $ref: "#/components/schemas/ConstraintViolationProblem"
+                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
@@ -449,14 +449,6 @@ paths:
               $ref: "#/components/schemas/ConfidentialityUpdateRequest"
         required: true
       responses:
-        "404":
-          description: Not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        "200":
-          description: Successful operation
         "400":
           description: Bad request
           content:
@@ -465,6 +457,14 @@ paths:
                 oneOf:
                 - $ref: "#/components/schemas/Problem"
                 - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "200":
+          description: Successful operation
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
@@ -494,6 +494,14 @@ paths:
           type: string
         example: EMPLOYMENT_CERTIFICATE
       responses:
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "200":
           description: Successful operation
           content:
@@ -503,14 +511,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/DocumentType"
-        "400":
-          description: Bad request
-          content:
-            application/problem+json:
-              schema:
-                oneOf:
-                - $ref: "#/components/schemas/Problem"
-                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -540,8 +540,6 @@ paths:
           type: string
         example: EMPLOYMENT_CERTIFICATE
       responses:
-        "204":
-          description: Successful operation
         "400":
           description: Bad request
           content:
@@ -556,6 +554,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+        "204":
+          description: Successful operation
         "404":
           description: Not Found
           content:
@@ -590,8 +590,6 @@ paths:
               $ref: "#/components/schemas/DocumentTypeUpdateRequest"
         required: true
       responses:
-        "204":
-          description: Successful operation
         "400":
           description: Bad request
           content:
@@ -606,6 +604,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+        "204":
+          description: Successful operation
         "404":
           description: Not Found
           content:
@@ -667,6 +667,14 @@ paths:
           items:
             type: string
       responses:
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "200":
           description: Successful operation
           content:
@@ -676,14 +684,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/PagedDocumentResponse"
-        "400":
-          description: Bad request
-          content:
-            application/problem+json:
-              schema:
-                oneOf:
-                - $ref: "#/components/schemas/Problem"
-                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -729,12 +729,14 @@ paths:
           default: false
         example: true
       responses:
-        "404":
-          description: Not found
+        "400":
+          description: Bad request
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/Problem"
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "200":
           description: Successful operation
           content:
@@ -744,14 +746,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Document"
-        "400":
-          description: Bad request
+        "404":
+          description: Not found
           content:
             application/problem+json:
               schema:
-                oneOf:
-                - $ref: "#/components/schemas/Problem"
-                - $ref: "#/components/schemas/ConstraintViolationProblem"
+                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
@@ -804,14 +804,6 @@ paths:
           default: false
         example: true
       responses:
-        "404":
-          description: Not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        "200":
-          description: Successful operation
         "400":
           description: Bad request
           content:
@@ -820,6 +812,14 @@ paths:
                 oneOf:
                 - $ref: "#/components/schemas/Problem"
                 - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "200":
+          description: Successful operation
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
@@ -863,14 +863,6 @@ paths:
           default: false
         example: true
       responses:
-        "404":
-          description: Not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        "200":
-          description: Successful operation
         "400":
           description: Bad request
           content:
@@ -879,6 +871,14 @@ paths:
                 oneOf:
                 - $ref: "#/components/schemas/Problem"
                 - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "200":
+          description: Successful operation
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
@@ -913,14 +913,6 @@ paths:
           type: string
         example: 082ba08f-03c7-409f-b8a6-940a1397ba38
       responses:
-        "404":
-          description: Not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        "204":
-          description: Successful operation
         "400":
           description: Bad request
           content:
@@ -929,12 +921,20 @@ paths:
                 oneOf:
                 - $ref: "#/components/schemas/Problem"
                 - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
+        "204":
+          description: Successful operation
   /api-docs:
     get:
       tags:
@@ -978,9 +978,9 @@ components:
             type: object
         status:
           $ref: "#/components/schemas/StatusType"
-        detail:
-          type: string
         title:
+          type: string
+        detail:
           type: string
     StatusType:
       type: object
@@ -1113,9 +1113,9 @@ components:
             type: object
         status:
           $ref: "#/components/schemas/StatusType"
-        detail:
-          type: string
         title:
+          type: string
+        detail:
           type: string
         suppressed:
           type: array
@@ -1176,6 +1176,7 @@ components:
       - createdBy
       - description
       - metadataList
+      - type
       type: object
       properties:
         createdBy:
@@ -1200,6 +1201,11 @@ components:
           description: List of DocumentMetadata objects.
           items:
             $ref: "#/components/schemas/DocumentMetadata"
+        type:
+          type: string
+          description: The type of document (validated against a defined list of document
+            types).
+          example: EMPLOYMENT_CERTIFICATE
       description: Document
     DocumentMetadata:
       required:
@@ -1260,6 +1266,11 @@ components:
           description: List of DocumentMetadata objects.
           items:
             $ref: "#/components/schemas/DocumentMetadata"
+        type:
+          type: string
+          description: The type of document (validated against a defined list of document
+            types).
+          example: EMPLOYMENT_CERTIFICATE
       description: DocumentUpdateRequest model.
     Document:
       type: object
@@ -1310,6 +1321,10 @@ components:
           description: Document data
           items:
             $ref: "#/components/schemas/DocumentData"
+        type:
+          type: string
+          description: Document type
+          example: Type for the document.
       description: Document model.
       readOnly: true
     DocumentData:


### PR DESCRIPTION
- Added document type attribute to existing document classes
- Added validator to validate document type against values stored in database

Observe that the ordinary validation annotation can not be used as we are dealing with multipart content in the resource and need to use jakarta instead of spring to instansiate the validator classes (which can't handle bean injection done by spring.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
