### PR TITLE
UF-14530 Validate Content-Type

### DIFF
--- a/src/main/java/se/sundsvall/document/api/DocumentResource.java
+++ b/src/main/java/se/sundsvall/document/api/DocumentResource.java
@@ -100,10 +100,6 @@ class DocumentResource {
 		@Parameter(name = "municipalityId", description = "Municipality ID", example = "2281") @PathVariable("municipalityId") @ValidMunicipalityId final String municipalityId,
 		@RequestPart("document") @Schema(description = "Document", implementation = DocumentCreateRequest.class) final String documentString,
 		@RequestPart(value = "documentFiles") @ValidContentType final List<MultipartFile> documentFiles) throws JsonProcessingException {
-
-		documentFiles.stream()
-			.map(MultipartFile::getContentType)
-			.forEach(System.out::println);
 		// If parameter isn't a String an exception (bad content type) will be thrown. Manual deserialization is necessary.
 		final var body = objectMapper.readValue(documentString, DocumentCreateRequest.class);
 		validate(body);

--- a/src/main/java/se/sundsvall/document/api/DocumentResource.java
+++ b/src/main/java/se/sundsvall/document/api/DocumentResource.java
@@ -61,6 +61,7 @@ import se.sundsvall.document.api.model.DocumentParameters;
 import se.sundsvall.document.api.model.DocumentUpdateRequest;
 import se.sundsvall.document.api.model.PagedDocumentResponse;
 import se.sundsvall.document.api.validation.DocumentTypeValidator;
+import se.sundsvall.document.api.validation.ValidContentType;
 import se.sundsvall.document.service.DocumentService;
 
 @RestController
@@ -98,8 +99,11 @@ class DocumentResource {
 	ResponseEntity<Void> create(
 		@Parameter(name = "municipalityId", description = "Municipality ID", example = "2281") @PathVariable("municipalityId") @ValidMunicipalityId final String municipalityId,
 		@RequestPart("document") @Schema(description = "Document", implementation = DocumentCreateRequest.class) final String documentString,
-		@RequestPart(value = "documentFiles") final List<MultipartFile> documentFiles) throws JsonProcessingException {
+		@RequestPart(value = "documentFiles") @ValidContentType final List<MultipartFile> documentFiles) throws JsonProcessingException {
 
+		documentFiles.stream()
+			.map(MultipartFile::getContentType)
+			.forEach(System.out::println);
 		// If parameter isn't a String an exception (bad content type) will be thrown. Manual deserialization is necessary.
 		final var body = objectMapper.readValue(documentString, DocumentCreateRequest.class);
 		validate(body);

--- a/src/main/java/se/sundsvall/document/api/validation/ValidContentType.java
+++ b/src/main/java/se/sundsvall/document/api/validation/ValidContentType.java
@@ -1,0 +1,23 @@
+package se.sundsvall.document.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({
+	ElementType.FIELD, ElementType.PARAMETER
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidContentTypeConstraintValidator.class)
+public @interface ValidContentType {
+
+	String message() default "content type must not be application/octet-stream";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/se/sundsvall/document/api/validation/ValidContentTypeConstraintValidator.java
+++ b/src/main/java/se/sundsvall/document/api/validation/ValidContentTypeConstraintValidator.java
@@ -1,0 +1,16 @@
+package se.sundsvall.document.api.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ValidContentTypeConstraintValidator implements ConstraintValidator<ValidContentType, List<MultipartFile>> {
+
+	@Override
+	public boolean isValid(final List<MultipartFile> files, final ConstraintValidatorContext context) {
+		return files.stream()
+			.map(MultipartFile::getContentType)
+			.noneMatch("application/octet-stream"::equals);
+	}
+}


### PR DESCRIPTION
Added validator that checks that no files are of content-type application/octet-stream. This constraint ensures that the client will have to set the content-type as application/octet-stream is the default value.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [x] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
