### PR TITLE
UF-15844 OAuth2Interceptor

### DIFF
--- a/src/main/java/se/sundsvall/document/integration/eventlog/configuration/EventlogConfiguration.java
+++ b/src/main/java/se/sundsvall/document/integration/eventlog/configuration/EventlogConfiguration.java
@@ -15,10 +15,14 @@ public class EventlogConfiguration {
 
 	@Bean
 	FeignBuilderCustomizer feignBuilderCustomizer(EventlogProperties eventlogProperties, ClientRegistrationRepository clientRegistrationRepository) {
-		return FeignMultiCustomizer.create()
+		var feignMultiCustomizer = FeignMultiCustomizer.create()
 			.withErrorDecoder(new ProblemErrorDecoder(CLIENT_ID))
-			.withRequestTimeoutsInSeconds(eventlogProperties.connectTimeout(), eventlogProperties.readTimeout())
-			.withRetryableOAuth2InterceptorForClientRegistration(clientRegistrationRepository.findByRegistrationId(CLIENT_ID))
-			.composeCustomizersToOne();
+			.withRequestTimeoutsInSeconds(eventlogProperties.connectTimeout(), eventlogProperties.readTimeout());
+
+		if (clientRegistrationRepository.findByRegistrationId(CLIENT_ID) != null) {
+			feignMultiCustomizer.withRetryableOAuth2InterceptorForClientRegistration(clientRegistrationRepository.findByRegistrationId(CLIENT_ID));
+		}
+
+		return feignMultiCustomizer.composeCustomizersToOne();
 	}
 }


### PR DESCRIPTION
* Makes the retryableOauth2InterceptorForClientRegistration optional, based on the presence of the property.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
