### PR TITLE
UF-15844: Adjusted optional configuration of oauth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,8 @@ target/
 # Local environment
 .env
 
-# Spring
-application-default.properties
+# Spring default profile
+application-default.*
+
+# Docker file
+Dockerfile*

--- a/src/main/java/se/sundsvall/document/integration/eventlog/configuration/EventlogConfiguration.java
+++ b/src/main/java/se/sundsvall/document/integration/eventlog/configuration/EventlogConfiguration.java
@@ -1,5 +1,8 @@
 package se.sundsvall.document.integration.eventlog.configuration;
 
+import static java.util.Objects.nonNull;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -14,12 +17,12 @@ public class EventlogConfiguration {
 	public static final String CLIENT_ID = "eventlog";
 
 	@Bean
-	FeignBuilderCustomizer feignBuilderCustomizer(EventlogProperties eventlogProperties, ClientRegistrationRepository clientRegistrationRepository) {
-		var feignMultiCustomizer = FeignMultiCustomizer.create()
+	FeignBuilderCustomizer feignBuilderCustomizer(EventlogProperties eventlogProperties, @Autowired(required = false) ClientRegistrationRepository clientRegistrationRepository) {
+		final var feignMultiCustomizer = FeignMultiCustomizer.create()
 			.withErrorDecoder(new ProblemErrorDecoder(CLIENT_ID))
 			.withRequestTimeoutsInSeconds(eventlogProperties.connectTimeout(), eventlogProperties.readTimeout());
 
-		if (clientRegistrationRepository.findByRegistrationId(CLIENT_ID) != null) {
+		if (nonNull(clientRegistrationRepository)) {
 			feignMultiCustomizer.withRetryableOAuth2InterceptorForClientRegistration(clientRegistrationRepository.findByRegistrationId(CLIENT_ID));
 		}
 

--- a/src/main/resources/application-it.yml
+++ b/src/main/resources/application-it.yml
@@ -23,5 +23,7 @@ spring:
             token-uri: http://localhost:${wiremock.server.port:}/api-gateway/token
         registration:
           eventlog:
+            authorization-grant-type: client_credentials
+            provider: eventlog
             client-id: the-client-id
             client-secret: the-client-secret

--- a/src/main/resources/application-junit.yml
+++ b/src/main/resources/application-junit.yml
@@ -34,5 +34,7 @@ spring:
             token-uri: http://localhost:${wiremock.server.port:}/api-gateway/token
         registration:
           eventlog:
+            authorization-grant-type: client_credentials
+            provider: eventlog
             client-id: the-client-id
             client-secret: the-client-secret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,13 +38,6 @@ spring:
     cache-names: documentTypeCache
     caffeine:
       spec: maximumSize=500, expireAfterWrite=600s
-  security:
-    oauth2:
-      client:
-        registration:
-          eventlog:
-            authorization-grant-type: client_credentials
-            provider: eventlog
   servlet:
     multipart:
       max-file-size: 60MB

--- a/src/test/java/se/sundsvall/document/integration/eventlog/configuration/EventlogConfigurationTest.java
+++ b/src/test/java/se/sundsvall/document/integration/eventlog/configuration/EventlogConfigurationTest.java
@@ -115,7 +115,7 @@ class EventlogConfigurationTest {
 
 			verify(feignMultiCustomizerSpy).withErrorDecoder(errorDecoderCaptor.capture());
 			verify(clientRegistrationRepositoryMock, never()).findByRegistrationId(CLIENT_ID);
-			verify(feignMultiCustomizerSpy, never()).withRetryableOAuth2InterceptorForClientRegistration(same(clientRegistrationMock));
+			verify(feignMultiCustomizerSpy, never()).withRetryableOAuth2InterceptorForClientRegistration(any());
 			verify(propertiesMock).connectTimeout();
 			verify(propertiesMock).readTimeout();
 			verify(feignMultiCustomizerSpy).withRequestTimeoutsInSeconds(1, 2);


### PR DESCRIPTION
- Removed section defining oauth2 client registration from root config (this must instead be defined in each environment config)
- Made clientRegistrationRepository argument optional with check to only add oauth2 interceptor if it is present

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
